### PR TITLE
docs: add comprehensive shortcuts reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ Built on NvChad v2.5 with Lazy.nvim plugin manager.
 - Ctrl+b: Split horizontal
 - Ctrl+z: Zoom pane
 - Ctrl+x: Copy mode
+- CMD+w: Close current tab
 - Leader+hjkl: Resize panes
 - Leader+w: Tab navigator
 - Leader+f: Toggle fullscreen

--- a/README.md
+++ b/README.md
@@ -38,6 +38,85 @@
  - `stow nvim`
  - `source ~/.zshrc`
 
+## Shortcuts
+
+### Wezterm
+
+**Leader Key:** `Ctrl+A`
+
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+'` | Split vertical |
+| `Ctrl+b` | Split horizontal |
+| `Ctrl+h/j/k/l` | Navigate between panes (nvim/wezterm) |
+| `Ctrl+z` | Zoom pane |
+| `Ctrl+x` | Copy mode |
+| `CMD+w` | Close current tab |
+| `Leader+h/j/k/l` | Resize panes |
+| `Leader+w` | Tab navigator |
+| `Leader+f` | Toggle fullscreen |
+
+### Neovim
+
+**Leader Key:** `Space`
+
+#### File Navigation
+| Shortcut | Action |
+|----------|--------|
+| `<leader>e` | Focus current file in tree |
+| `Ctrl+h/j/k/l` | Navigate between splits |
+| `s` + motion | Flash jump (quick navigation) |
+
+#### Code Navigation
+| Shortcut | Action |
+|----------|--------|
+| `gd` | Go to definition |
+| `gD` | Go to declaration |
+| `gi` | Go to implementation |
+| `gr` | View references (telescope) |
+| `<leader>D` | Go to type definition |
+| `gpd` | Preview definition |
+| `gpt` | Preview type definition |
+| `gpi` | Preview implementation |
+| `gpD` | Preview declaration |
+| `gpr` | Preview references |
+| `gP` | Close preview |
+
+#### Code Actions
+| Shortcut | Action |
+|----------|--------|
+| `ga` | Code actions |
+| `<leader>ra` | Rename symbol |
+| `<leader>S` | Search and replace (GrugFar) |
+
+#### Tabs & Buffers
+| Shortcut | Action |
+|----------|--------|
+| `gC` | New tab |
+| `gt` | Next tab |
+| `gT` | Previous tab |
+| `<leader>X` | Close all other buffers |
+
+#### Git
+| Shortcut | Action |
+|----------|--------|
+| `<leader>gh` | Open Neogit |
+
+#### General
+| Shortcut | Action |
+|----------|--------|
+| `<leader>w` | Write (save) |
+| `<leader>q` | Quit |
+| `<leader>Q` | Quit all |
+
+### ZSH
+
+| Shortcut | Action |
+|----------|--------|
+| `Ctrl+Space` | Accept autosuggestion |
+| `ls` | Enhanced tree view (eza) with git-ignore |
+| `cd` → `z` | Smart directory jumping (zoxide) |
+
 ### Deprecated
 
  - `kitty`


### PR DESCRIPTION
## Summary
- Added detailed shortcuts documentation to README.md covering Wezterm, Neovim, and ZSH key bindings
- Updated CLAUDE.md with missing CMD+w shortcut for closing tabs
- Organized shortcuts into categorized tables for easy reference

## Test plan
- [ ] Verify README.md displays shortcuts correctly on GitHub
- [ ] Confirm all shortcuts are accurate and match actual configurations
- [ ] Check that tables render properly in markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)