### PR TITLE
fix: configure nvim-tree keybindings for proper navigation

### DIFF
--- a/nvim/.config/nvim/lua/plugins/init.lua
+++ b/nvim/.config/nvim/lua/plugins/init.lua
@@ -90,6 +90,25 @@ return {
   {
     "nvim-tree/nvim-tree.lua",
     opts = {
+      on_attach = function(bufnr)
+        local api = require "nvim-tree.api"
+        local function opts(desc)
+          return { desc = "nvim-tree: " .. desc, buffer = bufnr, noremap = true, silent = true, nowait = true }
+        end
+
+        -- Load default mappings first
+        api.config.mappings.default_on_attach(bufnr)
+
+        -- Explicitly ensure h and l work for navigation
+        vim.keymap.set("n", "h", api.node.navigate.parent_close, opts "Close Directory")
+        vim.keymap.set("n", "l", api.node.open.edit, opts "Open")
+
+        -- Preserve smart-splits navigation with CTRL+hjkl
+        vim.keymap.set("n", "<C-h>", require("smart-splits").move_cursor_left, opts "Move to left pane")
+        vim.keymap.set("n", "<C-j>", require("smart-splits").move_cursor_down, opts "Move to bottom pane")
+        vim.keymap.set("n", "<C-k>", require("smart-splits").move_cursor_up, opts "Move to top pane")
+        vim.keymap.set("n", "<C-l>", require("smart-splits").move_cursor_right, opts "Move to right pane")
+      end,
       actions = {
         change_dir = {
           global = true,


### PR DESCRIPTION
## Summary
- Added `on_attach` function to nvim-tree configuration to enable default keybindings
- Configured `h` key to collapse folders and `l` key to expand/open folders in nvim-tree
- Preserved smart-splits navigation (`CTRL+hjkl`) for moving between Neovim and terminal panes

## Problem
nvim-tree's default keybindings were not working, specifically the `h` key to collapse folders. Additionally, `CTRL+k` was being overridden by nvim-tree, breaking smart-splits pane navigation.

## Solution
Explicitly configured nvim-tree's `on_attach` function to:
1. Load default nvim-tree mappings (`h`/`l` for tree navigation)
2. Override with smart-splits bindings (`CTRL+hjkl`) to ensure pane switching works from within nvim-tree

## Test plan
- [ ] Open nvim-tree and verify `h` collapses folders
- [ ] Verify `l` expands folders
- [ ] Confirm `CTRL+h/j/k/l` moves between panes from within nvim-tree buffer
- [ ] Verify all shortcuts work after Neovim restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)