### PR TITLE
feat: add wezterm shortcuts for pane movement and rotation

### DIFF
--- a/wezterm/.config/wezterm/config.lua
+++ b/wezterm/.config/wezterm/config.lua
@@ -249,6 +249,21 @@ config = {
 			action = wezterm.action.AdjustPaneSize({ "Right", 10 }),
 		},
 		{
+			key = "r",
+			mods = "LEADER",
+			action = wezterm.action.RotatePanes("Clockwise"),
+		},
+		{
+			key = "r",
+			mods = "LEADER|SHIFT",
+			action = wezterm.action.RotatePanes("CounterClockwise"),
+		},
+		{
+			key = "s",
+			mods = "LEADER",
+			action = wezterm.action.PaneSelect({ mode = "SwapWithActive" }),
+		},
+		{
 			key = "w",
 			mods = "LEADER",
 			action = wezterm.action.ShowTabNavigator,


### PR DESCRIPTION
## Summary
- Added `LEADER+r` shortcut to rotate panes clockwise
- Added `LEADER+R` (SHIFT+r) shortcut to rotate panes counter-clockwise  
- Added `LEADER+s` shortcut for interactive pane swap selection

## Problem
Wezterm configuration had shortcuts for pane navigation (CTRL+hjkl) and resizing (LEADER+hjkl), but was missing shortcuts to move or rotate panes.

## Solution
Added three new keybindings using wezterm's built-in actions:
1. **RotatePanes("Clockwise")** - Cycles panes in clockwise order
2. **RotatePanes("CounterClockwise")** - Cycles panes in counter-clockwise order
3. **PaneSelect({ mode = "SwapWithActive" })** - Interactive mode that shows numbers on each pane and lets you select which one to swap with the active pane

## Test plan
- [ ] Verify `LEADER+r` (CTRL+a, then r) rotates panes clockwise
- [ ] Verify `LEADER+R` (CTRL+a, then SHIFT+r) rotates panes counter-clockwise
- [ ] Verify `LEADER+s` (CTRL+a, then s) opens interactive pane selection
- [ ] Confirm interactive swap correctly swaps selected pane with active pane
- [ ] Verify shortcuts work with wezterm's auto-reload (no restart needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)