### PR TITLE
chore: change tmux leader key from C-a to C-f

### DIFF
--- a/tmux/.config/tmux/tmux.conf
+++ b/tmux/.config/tmux/tmux.conf
@@ -1,9 +1,9 @@
 set -g escape-time 0
 
-# NOTE: rebind leader from C-b to C-a
-set -g prefix C-a
+# NOTE: rebind leader from C-b to C-f
+set -g prefix C-f
 unbind-key C-b
-bind-key C-a send-prefix
+bind-key C-f send-prefix
 
 # NOTE: rebind rename window
 bind r command-prompt -I'#W' { rename-window -- '%%' }


### PR DESCRIPTION
## Summary
- Updated tmux prefix key from `C-a` (Ctrl+A) to `C-f` (Ctrl+F)
- Modified prefix binding and send-prefix command to use new key

This change improves ergonomics and avoids conflicts with shell line navigation commands (Ctrl+A jumps to beginning of line in many shells).

## Test plan
- [ ] Verify tmux config loads without errors
- [ ] Confirm `C-f` activates tmux prefix
- [ ] Test that `C-f` + other commands work as expected (e.g., `C-f c` for new window)
- [ ] Ensure shell Ctrl+A still works for line navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)