### PR TITLE
feat: add AWS terminal tools (e1s/e2s) with interactive selection

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -1,6 +1,9 @@
 # Homebrew
 eval "$(/opt/homebrew/bin/brew shellenv)"
 
+# Add local bin to PATH
+export PATH="$PATH:$HOME/.local/bin"
+
 # Force k9s to use XDG config directory (cross-platform)
 export K9S_CONFIG_DIR="$HOME/.config/k9s"
 


### PR DESCRIPTION
## Summary

- Add **e1s** (AWS ECS) floating terminal on **ALT+1** with interactive profile/region selection
- Add **e2s** (AWS EC2 browser) floating terminal on **ALT+2** with auto-start
- Add `~/.local/bin` to PATH in zsh for e2s binary access
- Reorganize all floating terminal offsets (0.02 to 0.12) for visual stacking
- Update terminal kill mapping (ALT+p) to reset e1s/e2s flags

## New Keybindings

- **ALT+1**: e1s - AWS ECS cluster browser
  - Interactive fzf menus: profile → region → ECS cluster/service
  - Auto-launches with selection on first open
  
- **ALT+2**: e2s - AWS EC2 instance browser  
  - Interactive fzf menus: profile → region → EC2 instance → actions
  - Auto-launches on first open
  - Repository: https://github.com/christophermanahan/e2s

## Terminal Organization

All 11 floating terminals now use evenly-spaced cascading offsets:

| Key    | Tool       | Offset | Description              |
|--------|------------|--------|--------------------------|
| ALT+k  | Claude     | 0.02   | Claude Code CLI          |
| ALT+i  | Tmux       | 0.03   | Multiplexer terminal     |
| ALT+j  | k9s        | 0.04   | Kubernetes browser       |
| ALT+h  | Lazygit    | 0.05   | Git TUI                  |
| ALT+o  | OpenAI     | 0.06   | Codex CLI                |
| ALT+b  | Browsh     | 0.07   | Terminal browser         |
| ALT+d  | Lazydocker | 0.08   | Docker TUI               |
| ALT+e  | w3m        | 0.09   | w3m browser              |
| ALT+c  | Carbonyl   | 0.10   | Chromium terminal        |
| ALT+1  | e1s        | 0.11   | AWS ECS browser          |
| ALT+2  | e2s        | 0.12   | AWS EC2 browser          |

## Testing

Tested with real AWS profiles:
- [x] e1s profile/region selection flow
- [x] e2s profile/region → instance selection flow
- [x] PATH addition allows e2s to run
- [x] ALT+p properly resets e1s/e2s flags
- [x] All 11 terminals cascade visually without overlap

## Related

- e2s repository: https://github.com/christophermanahan/e2s
- Both tools follow k9s integration pattern
- e1s is external tool (ECS), e2s is custom-built (EC2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)