### PR TITLE
feat: add posting API client floating terminal

### DIFF
--- a/nvim/.config/nvim/lua/mappings.lua
+++ b/nvim/.config/nvim/lua/mappings.lua
@@ -1277,7 +1277,32 @@ fi
   end
 end, { desc = "terminal toggle e1s AWS ECS" })
 
--- ALT+p closes and kills any floating terminal (ALT+i/k/j/h/o/b/d/e/c)
+-- ALT+u toggles the posting terminal (API client)
+map({ "n", "t" }, "<A-u>", function()
+  local term = require "nvchad.term"
+
+  -- Prepare: handle foreground terminal switching if needed
+  local should_toggle = prepare_toggle("posting_term")
+
+  -- Only toggle if prepare_toggle says we should
+  if should_toggle then
+    term.toggle {
+      pos = "float",
+      id = "posting_term",
+      cmd = "posting",
+      float_opts = {
+        row = 0.12, -- ALT+u: Posting API client
+        col = 0.12,
+        width = 0.85,
+        height = 0.85,
+        title = "Posting 📮",
+        title_pos = "center",
+      }
+    }
+  end
+end, { desc = "terminal toggle posting API client" })
+
+-- ALT+p closes and kills any floating terminal (ALT+i/k/j/h/o/b/d/e/c/u)
 -- Note: When in terminal mode with apps like k9s running, press Ctrl+q first to exit terminal mode,
 -- then press ALT+p. Or use this mapping which attempts to kill the process first.
 map({ "n", "t" }, "<A-p>", function()


### PR DESCRIPTION
## Summary

Adds a floating terminal for [posting](https://github.com/darrenburns/posting), a modern TUI HTTP API client similar to Postman/Insomnia, bound to ALT+u.

## Motivation

Posting provides a keyboard-driven interface for testing HTTP APIs directly within the development environment, complementing the existing suite of CLI tools (k9s, lazygit, claude, etc.).

## Changes

- ✅ Add posting terminal with ALT+u keybinding
- ✅ Terminal ID: `posting_term`
- ✅ Cascading window position (offset: 0.12)
- ✅ Auto-starts posting on first open
- ✅ Integrated with foreground terminal tracking system
- ✅ Works with ALT+p to close

## User Experience

**Open posting:** Press `ALT+u`  
**Close posting:** Press `ALT+u` again or `ALT+p`

The terminal opens at row/col 0.12 with 85% screen size and displays "Posting 📮" in the title bar.

## Requirements

Install posting via homebrew:
```bash
brew install posting
```

## Terminal Layout

All floating terminals now use cascading offsets:

| Key       | Tool       | Offset | Description              |
|-----------|------------|--------|--------------------------|
| ALT+k     | Claude     | 0.02   | Claude Code CLI          |
| ALT+i     | Tmux       | 0.03   | Multiplexer terminal     |
| ALT+j     | k9s        | 0.04   | Kubernetes browser       |
| ALT+h     | Lazygit    | 0.05   | Git TUI                  |
| ALT+o     | OpenAI     | 0.06   | Codex CLI                |
| ALT+b     | Browsh     | 0.07   | Terminal browser         |
| ALT+d     | Lazydocker | 0.08   | Docker TUI               |
| ALT+e     | w3m        | 0.09   | w3m browser              |
| ALT+c     | Carbonyl   | 0.10   | Chromium terminal        |
| ALT+Shift+J | e1s      | 0.11   | AWS ECS browser          |
| **ALT+u** | **Posting** | **0.12** | **HTTP API client**  |

## Note on Vim Keybindings

Posting's current keymap system only supports remapping 14 application-specific actions (e.g., `send-request`, `focus-url`) and does not expose basic navigation keys for remapping. To add vim-style navigation (jkl; → arrow keys), native vim keybinding support would need to be implemented by the posting developer.

## Testing

- [x] Terminal opens with ALT+u
- [x] Posting auto-starts correctly
- [x] Terminal closes with ALT+u
- [x] Terminal closes with ALT+p
- [x] Foreground terminal tracking works
- [x] No conflicts with existing keybindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)