### PR TITLE
fix: capture terminal buffers immediately after toggle

### DIFF
--- a/nvim/.config/nvim/lua/mappings.lua
+++ b/nvim/.config/nvim/lua/mappings.lua
@@ -547,9 +547,9 @@ map({ "n", "t" }, "<A-q>", function()
 
   -- Auto-start the search on first open
   if not _G.fzf_all_started then
+    local bufnr = vim.api.nvim_get_current_buf()  -- Capture buffer immediately
     vim.defer_fn(function()
-      -- Find the terminal buffer by term_id to avoid race conditions
-      local bufnr = find_term_buffer("fzf_all_commands")
+      -- Use the captured buffer to avoid race conditions
       if bufnr and vim.bo[bufnr].buftype == "terminal" then
         local chan = vim.b[bufnr].terminal_job_id
         if chan then
@@ -579,9 +579,9 @@ map({ "n", "t" }, "<A-G>", function()
   }
 
   if not _G.fzf_git_started then
+    local bufnr = vim.api.nvim_get_current_buf()  -- Capture buffer immediately
     vim.defer_fn(function()
-      -- Find the terminal buffer by term_id to avoid race conditions
-      local bufnr = find_term_buffer("fzf_git_commands")
+      -- Use the captured buffer to avoid race conditions
       if bufnr and vim.bo[bufnr].buftype == "terminal" then
         local chan = vim.b[bufnr].terminal_job_id
         if chan then
@@ -611,9 +611,9 @@ map({ "n", "t" }, "<A-D>", function()
   }
 
   if not _G.fzf_docker_started then
+    local bufnr = vim.api.nvim_get_current_buf()  -- Capture buffer immediately
     vim.defer_fn(function()
-      -- Find the terminal buffer by term_id to avoid race conditions
-      local bufnr = find_term_buffer("fzf_docker_commands")
+      -- Use the captured buffer to avoid race conditions
       if bufnr and vim.bo[bufnr].buftype == "terminal" then
         local chan = vim.b[bufnr].terminal_job_id
         if chan then
@@ -643,9 +643,9 @@ map({ "n", "t" }, "<A-A>", function()
   }
 
   if not _G.fzf_aws_started then
+    local bufnr = vim.api.nvim_get_current_buf()  -- Capture buffer immediately
     vim.defer_fn(function()
-      -- Find the terminal buffer by term_id to avoid race conditions
-      local bufnr = find_term_buffer("fzf_aws_commands")
+      -- Use the captured buffer to avoid race conditions
       if bufnr and vim.bo[bufnr].buftype == "terminal" then
         local chan = vim.b[bufnr].terminal_job_id
         if chan then
@@ -675,9 +675,9 @@ map({ "n", "t" }, "<A-X>", function()
   }
 
   if not _G.fzf_alias_started then
+    local bufnr = vim.api.nvim_get_current_buf()  -- Capture buffer immediately
     vim.defer_fn(function()
-      -- Find the terminal buffer by term_id to avoid race conditions
-      local bufnr = find_term_buffer("fzf_aliases")
+      -- Use the captured buffer to avoid race conditions
       if bufnr and vim.bo[bufnr].buftype == "terminal" then
         local chan = vim.b[bufnr].terminal_job_id
         if chan then
@@ -707,9 +707,9 @@ map({ "n", "t" }, "<A-B>", function()
   }
 
   if not _G.fzf_brew_started then
+    local bufnr = vim.api.nvim_get_current_buf()  -- Capture buffer immediately
     vim.defer_fn(function()
-      -- Find the terminal buffer by term_id to avoid race conditions
-      local bufnr = find_term_buffer("fzf_brew")
+      -- Use the captured buffer to avoid race conditions
       if bufnr and vim.bo[bufnr].buftype == "terminal" then
         local chan = vim.b[bufnr].terminal_job_id
         if chan then
@@ -750,9 +750,10 @@ map({ "n", "t" }, "<A-k>", function()
 
   -- If this is the first time opening and we haven't started Claude yet
   if should_toggle and not _G.claude_started then
+    -- Capture the buffer immediately after toggle (before defer_fn)
+    local bufnr = vim.api.nvim_get_current_buf()
     vim.defer_fn(function()
-      -- Find the Claude terminal buffer by term_id to avoid race conditions
-      local bufnr = find_term_buffer("claude_term")
+      -- Use the captured buffer to avoid race conditions
 
       -- Check if we found the terminal buffer
       if bufnr and vim.bo[bufnr].buftype == "terminal" then
@@ -849,9 +850,9 @@ map({ "n", "t" }, "<A-i>", function()
   -- Auto-start tmux on first open and track the buffer number
   if should_toggle then
     local session_name = "nvim_" .. nvim_pid  -- Capture in closure
+    local bufnr = vim.api.nvim_get_current_buf()  -- Capture buffer immediately
     vim.defer_fn(function()
-      -- Find the tmux terminal buffer by term_id to avoid race conditions
-      local bufnr = find_term_buffer(term_id)
+      -- Use the captured buffer to avoid race conditions
 
       -- Check if we found the terminal buffer
       if bufnr and vim.bo[bufnr].buftype == "terminal" then
@@ -900,9 +901,9 @@ map({ "n", "t" }, "<A-j>", function()
 
   -- If this is the first time opening and we haven't started k9s yet
   if should_toggle and not _G.k9s_started then
+    local bufnr = vim.api.nvim_get_current_buf()  -- Capture buffer immediately
     vim.defer_fn(function()
-      -- Find the k9s terminal buffer by term_id to avoid race conditions
-      local bufnr = find_term_buffer("k9s_term")
+      -- Use the captured buffer to avoid race conditions
 
       -- Check if we found the terminal buffer
       if bufnr and vim.bo[bufnr].buftype == "terminal" then
@@ -1008,9 +1009,9 @@ map({ "n", "t" }, "<A-o>", function()
 
   -- If this is the first time opening and we haven't started OpenAI yet
   if should_toggle and not _G.openai_started then
+    local bufnr = vim.api.nvim_get_current_buf()  -- Capture buffer immediately
     vim.defer_fn(function()
-      -- Find the OpenAI terminal buffer by term_id to avoid race conditions
-      local bufnr = find_term_buffer("openai_term")
+      -- Use the captured buffer to avoid race conditions
 
       -- Check if we found the terminal buffer
       if bufnr and vim.bo[bufnr].buftype == "terminal" then
@@ -1048,10 +1049,10 @@ map({ "n", "t" }, "<A-d>", function()
 
   -- Auto-start lazydocker on first open
   if not _G.lazydocker_started then
+    local bufnr = vim.api.nvim_get_current_buf()  -- Capture buffer immediately
     vim.defer_fn(function()
       _G.lazydocker_started = true
-      -- Find the lazydocker terminal buffer by term_id to avoid race conditions
-      local bufnr = find_term_buffer("lazydockerTerm")
+      -- Use the captured buffer to avoid race conditions
       if bufnr and vim.bo[bufnr].buftype == "terminal" then
         local chan = vim.b[bufnr].terminal_job_id
         if chan then
@@ -1080,10 +1081,10 @@ map({ "n", "t" }, "<A-e>", function()
 
   -- Auto-start e1s with profile/region selection on first open
   if not _G.e1s_started then
+    local bufnr = vim.api.nvim_get_current_buf()  -- Capture buffer immediately
     vim.defer_fn(function()
       _G.e1s_started = true
-      -- Find the e1s terminal buffer by term_id to avoid race conditions
-      local bufnr = find_term_buffer("e1sTerm")
+      -- Use the captured buffer to avoid race conditions
       if bufnr and vim.bo[bufnr].buftype == "terminal" then
         local chan = vim.b[bufnr].terminal_job_id
         if chan then


### PR DESCRIPTION
## Summary

Fixes the issue where auto-start commands stopped working after the previous race condition fix. Terminals would open but commands wouldn't execute.

## Problem

After PR #29 replaced `vim.api.nvim_get_current_buf()` with `find_term_buffer(term_id)` to prevent race conditions, auto-start commands stopped working entirely. 

The issue: `find_term_buffer()` searches for buffers by their `term_id` buffer variable (`vim.b[buf].term_id`), but nvchad.term doesn't set this variable immediately when creating terminals. When the defer_fn callback fires 200ms later, term_id hasn't been set yet, so `find_term_buffer()` returns nil.

## Solution

Capture the buffer number immediately after calling `term.toggle` (when it's the current buffer), then use that captured buffer in the defer_fn callback via closure. This approach:

✅ Finds the buffer reliably (captured immediately)  
✅ Prevents race conditions (closure captures correct buffer)  
✅ Doesn't depend on term_id being set  

### Before (broken):
```lua
term.toggle { ... }
vim.defer_fn(function()
  local bufnr = find_term_buffer(term_id)  -- ❌ Returns nil, term_id not set yet
  if bufnr and vim.bo[bufnr].buftype == "terminal" then
    -- Never executes
  end
end, 200)
```

### After (working):
```lua
term.toggle { ... }
local bufnr = vim.api.nvim_get_current_buf()  -- ✅ Capture immediately
vim.defer_fn(function()
  -- Use captured bufnr from closure ✅
  if bufnr and vim.bo[bufnr].buftype == "terminal" then
    vim.api.nvim_chan_send(job_id, "command\n")  -- ✅ Executes correctly
  end
end, 200)
```

## How It Prevents Race Conditions

The closure captures the specific buffer that was just created:

1. **User opens tmux** (ALT+i)
   - `term.toggle` creates tmux terminal (buffer 5)
   - `bufnr = nvim_get_current_buf()` captures buffer 5
   - Closure stores buffer 5

2. **User immediately opens Claude** (ALT+k) 
   - `term.toggle` creates Claude terminal (buffer 6)
   - `bufnr = nvim_get_current_buf()` captures buffer 6
   - Closure stores buffer 6

3. **200ms later, both defer_fn callbacks fire**
   - Tmux callback uses its captured buffer 5 ✅
   - Claude callback uses its captured buffer 6 ✅
   - Commands go to correct terminals ✅

## Terminals Fixed (All 12)

### Tool Terminals (6)
- **ALT+k**: Claude Code
- **ALT+i**: Tmux multiplexer
- **ALT+j**: k9s Kubernetes
- **ALT+o**: OpenAI Codex CLI
- **ALT+d**: Lazydocker
- **ALT+e**: e1s AWS ECS

### Fuzzy Command Search Terminals (6)
- **Alt+Q**: All commands
- **Alt+Shift+G**: Git commands
- **Alt+Shift+D**: Docker/K8s commands
- **Alt+Shift+A**: AWS commands
- **Alt+Shift+X**: Aliases/functions
- **Alt+Shift+B**: Homebrew packages

## Changes

- **1 file changed**: `nvim/.config/nvim/lua/mappings.lua`
- **25 insertions, 24 deletions**
- Added `local bufnr = vim.api.nvim_get_current_buf()` before each defer_fn
- Replaced `find_term_buffer(term_id)` calls with captured `bufnr`
- Updated comments to explain closure capture pattern

## Testing

- [x] All 12 terminals open correctly
- [x] Auto-start commands execute in correct terminals
- [x] Claude session prompt works
- [x] k9s cluster selection works
- [x] e1s AWS profile/region selection works
- [x] All fzf search terminals start correctly
- [x] No race condition when rapidly toggling terminals
- [x] Lua syntax verified

## Related

- Fixes regression introduced in PR #29
- Maintains race condition fix while restoring functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)