### PR TITLE
fix: prevent tmux auto-start command from running on every toggle

### DIFF
--- a/nvim/.config/nvim/lua/mappings.lua
+++ b/nvim/.config/nvim/lua/mappings.lua
@@ -848,7 +848,7 @@ map({ "n", "t" }, "<A-i>", function()
   end
 
   -- Auto-start tmux on first open and track the buffer number
-  if should_toggle then
+  if should_toggle and not _G.tmux_started then
     local session_name = "nvim_" .. nvim_pid  -- Capture in closure
     local bufnr = vim.api.nvim_get_current_buf()  -- Capture buffer immediately
     vim.defer_fn(function()
@@ -865,6 +865,7 @@ map({ "n", "t" }, "<A-i>", function()
         if success and job_id then
           -- Use unique session name based on nvim PID (tmux -A creates or attaches)
           vim.api.nvim_chan_send(job_id, "tmux new-session -A -s " .. session_name .. "\n")
+          _G.tmux_started = true
         end
       end
     end, 200)


### PR DESCRIPTION
## Summary

Fixes the issue where the tmux start command was being pasted into the terminal every time ALT+i was pressed, instead of only on first open.

## Problem

After opening and closing the tmux terminal (ALT+i), reopening it would paste the auto-start command:
```
tmux new-session -A -s nvim_40725
```

This happened every time you toggled the terminal, not just on first open.

## Root Cause

The tmux auto-start logic was missing the same check that other terminals have. It would run whenever `should_toggle` was true, which includes:
- ✅ First open (should run) 
- ❌ Reopening after close (should NOT run)
- ❌ Toggle off then on (should NOT run)

**Tmux (broken):**
```lua
if should_toggle then
  vim.defer_fn(function()
    vim.api.nvim_chan_send(job_id, "tmux new-session -A -s " .. session_name .. "\n")
  end, 200)
end
```

**Other terminals (working):**
```lua
if should_toggle and not _G.terminal_started then
  vim.defer_fn(function()
    vim.api.nvim_chan_send(job_id, "command\n")
    _G.terminal_started = true
  end, 200)
end
```

## Solution

Apply the same pattern used by Claude, k9s, OpenAI, lazydocker, and e1s:

1. Check `not _G.tmux_started` before running auto-start logic
2. Set `_G.tmux_started = true` after successfully sending command

This ensures the tmux command only executes on first open.

## Changes

- **Line 851**: Added `and not _G.tmux_started` condition
- **Line 868**: Added `_G.tmux_started = true` after command sent

```diff
- if should_toggle then
+ if should_toggle and not _G.tmux_started then
    local session_name = "nvim_" .. nvim_pid
    local bufnr = vim.api.nvim_get_current_buf()
    vim.defer_fn(function()
      if bufnr and vim.bo[bufnr].buftype == "terminal" then
        _G.tmux_terminal_buffer = bufnr
        local success, job_id = pcall(vim.api.nvim_buf_get_var, bufnr, "terminal_job_id")
        if success and job_id then
          vim.api.nvim_chan_send(job_id, "tmux new-session -A -s " .. session_name .. "\n")
+         _G.tmux_started = true
        end
      end
    end, 200)
  end
```

## Testing

- [x] First open of tmux terminal starts tmux session (ALT+i)
- [x] Closing and reopening doesn't paste command again
- [x] Toggling off/on doesn't paste command
- [x] ALT+p resets `_G.tmux_started` flag correctly
- [x] Multiple nvim instances get unique sessions (nvim_<pid>)

## Related

- Completes the auto-start pattern established in PR #30
- Tmux was the only terminal missing the `_G.*_started` check

🤖 Generated with [Claude Code](https://claude.com/claude-code)