### PR TITLE
feat: remap all floating terminals to left-hand keys

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Overview
 
-**Paradiddle** is a CLI-first IDE where terminal tools are first-class citizens. Built on NvChad v2.5, it integrates 10 CLI tools as floating terminals with intelligent auto-start behavior, plus 6 fuzzy command search terminals for discovering executables.
+**Paradiddle** is a CLI-first IDE where terminal tools are first-class citizens. Built on NvChad v2.5, it integrates 8 CLI tools as floating terminals with intelligent auto-start behavior, plus 6 fuzzy command search terminals for discovering executables. All keybindings are optimized for left-hand access to work seamlessly with tiling window managers.
 
 Configuration files managed with GNU Stow:
-- **nvim**: CLI-first IDE with 16 integrated floating terminals:
-  - 10 tool terminals (ALT+k/i/j/h/o/b/d/e/c, ALT+Shift+J)
+- **nvim**: CLI-first IDE with 14 integrated floating terminals:
+  - 8 tool terminals (ALT+a/s/d/f/g/w/e/r) - left-hand optimized
   - 6 command search terminals (ALT+q, ALT+Shift+G/D/A/X/B)
 - **zsh**: Shell configuration with vi-mode, autosuggestions, and syntax highlighting
 - **starship**: Custom prompt with Catppuccin Mocha theme
@@ -88,8 +88,8 @@ Built on NvChad v2.5 with Lazy.nvim plugin manager.
 - Formatting: conform.nvim with prettierd (JS/TS/CSS/HTML) and stylua (Lua), auto-format on save
 - Completion: nvim-cmp with Copilot integration, LSP signature help
 - Navigation: smart-splits.nvim for seamless pane navigation with wezterm, flash.nvim for quick jumps
-- Git: lazygit (floating terminal via `ALT+h`) with diffview integration (gitsigns disabled)
-- Kubernetes: k9s (floating terminal via `ALT+j`) with cluster selection menu on first open
+- Git: lazygit (floating terminal via `ALT+f`) with diffview integration (gitsigns disabled)
+- Kubernetes: k9s (floating terminal via `ALT+g`) with cluster selection menu on first open
 - AI Assistant: avante.nvim (Cursor-like AI coding assistant) with Claude integration
 - UI enhancements: noice.nvim, nvim-notify, trouble.nvim, rainbow-delimiters
 
@@ -100,6 +100,33 @@ Built on NvChad v2.5 with Lazy.nvim plugin manager.
 - Telescope uses fzf extension for performance
 - TypeScript servers (tsserver, vtsls) and lua_ls have custom handler logic
 - Fuzzy command search available via `Alt+Q` (and variants) opens floating terminals with fzf search
+
+**Floating Terminal Keybindings (Left-Hand Optimized):**
+
+All terminal shortcuts use the left hand for easy access with tiling window managers:
+
+*Home Row (Most Used):*
+- `ALT+a`: Claude Code AI assistant
+- `ALT+s`: Tmux multiplexer terminal
+- `ALT+d`: Lazydocker (Docker TUI)
+- `ALT+f`: Lazygit (Git TUI)
+- `ALT+g`: k9s (Kubernetes browser)
+
+*Top Row (Secondary Tools):*
+- `ALT+w`: OpenAI Codex CLI
+- `ALT+e`: e1s (AWS ECS browser)
+- `ALT+r`: Posting (HTTP API client)
+
+*Bottom Row:*
+- `ALT+z`: Kill/close current floating terminal
+
+*Command Search (Unchanged):*
+- `ALT+q`: Search all commands
+- `ALT+Shift+G`: Git commands
+- `ALT+Shift+D`: Docker/K8s commands
+- `ALT+Shift+A`: AWS commands
+- `ALT+Shift+X`: Aliases/functions
+- `ALT+Shift+B`: Homebrew packages
 
 ### Wezterm
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,9 @@ All terminal shortcuts use the left hand for easy access with tiling window mana
 *Bottom Row:*
 - `ALT+z`: Kill/close current floating terminal
 
+*Help:*
+- `ALT+Shift+?`: Show terminal shortcuts cheatsheet
+
 *Command Search (Unchanged):*
 - `ALT+q`: Search all commands
 - `ALT+Shift+G`: Git commands

--- a/nvim/.config/nvim/lua/mappings.lua
+++ b/nvim/.config/nvim/lua/mappings.lua
@@ -725,8 +725,8 @@ end, { desc = "fuzzy search homebrew packages" })
 _G.claude_started = false
 _G.tmux_started = false
 
--- ALT+k toggles the Claude terminal and starts Claude on first open
-map({ "n", "t" }, "<A-k>", function()
+-- ALT+a toggles the Claude terminal and starts Claude on first open
+map({ "n", "t" }, "<A-a>", function()
   local term = require "nvchad.term"
 
   -- Prepare: handle foreground terminal switching if needed
@@ -738,7 +738,7 @@ map({ "n", "t" }, "<A-k>", function()
       pos = "float",
       id = "claude_term",
       float_opts = {
-        row = 0.02, -- ALT+k: Claude Code (top-left)
+        row = 0.02, -- ALT+a: Claude Code
         col = 0.02,
         width = 0.85,
         height = 0.85,
@@ -821,9 +821,9 @@ exec /tmp/claude_session_prompt_$$.sh
   end
 end, { desc = "terminal toggle claude code" })
 
--- ALT+i toggles the floating terminal and starts tmux on first open
+-- ALT+s toggles the floating terminal and starts tmux on first open
 -- Each nvim instance gets its own unique tmux session based on nvim PID
-map({ "n", "t" }, "<A-i>", function()
+map({ "n", "t" }, "<A-s>", function()
   local term = require "nvchad.term"
   local nvim_pid = vim.fn.getpid()
   local term_id = "floatTerm_" .. nvim_pid
@@ -837,7 +837,7 @@ map({ "n", "t" }, "<A-i>", function()
       pos = "float",
       id = term_id,
       float_opts = {
-        row = 0.03, -- ALT+i: Tmux terminal
+        row = 0.03, -- ALT+s: Tmux terminal
         col = 0.03,
         width = 0.85,
         height = 0.85,
@@ -872,8 +872,8 @@ map({ "n", "t" }, "<A-i>", function()
   end
 end, { desc = "terminal toggle floating with tmux" })
 
--- ALT+j toggles the k9s terminal with cluster selection on first open
-map({ "n", "t" }, "<A-j>", function()
+-- ALT+g toggles the k9s terminal with cluster selection on first open
+map({ "n", "t" }, "<A-g>", function()
   local term = require "nvchad.term"
 
   -- Prepare: handle foreground terminal switching if needed
@@ -885,7 +885,7 @@ map({ "n", "t" }, "<A-j>", function()
       pos = "float",
       id = "k9s_term",
       float_opts = {
-        row = 0.04, -- ALT+j: k9s
+        row = 0.04, -- ALT+g: k9s
         col = 0.04,
         width = 0.85,
         height = 0.85,
@@ -955,8 +955,8 @@ fi
   end
 end, { desc = "terminal toggle k9s with cluster selection" })
 
--- ALT+h toggles the lazygit terminal
-map({ "n", "t" }, "<A-h>", function()
+-- ALT+f toggles the lazygit terminal
+map({ "n", "t" }, "<A-f>", function()
   local term = require "nvchad.term"
 
   -- Prepare: handle foreground terminal switching if needed
@@ -969,7 +969,7 @@ map({ "n", "t" }, "<A-h>", function()
       id = "lazygit_term",
       cmd = "lazygit",
       float_opts = {
-        row = 0.05, -- ALT+h: Lazygit
+        row = 0.05, -- ALT+f: Lazygit
         col = 0.05,
         width = 0.85,
         height = 0.85,
@@ -980,8 +980,8 @@ map({ "n", "t" }, "<A-h>", function()
   end
 end, { desc = "terminal toggle lazygit" })
 
--- ALT+o toggles the OpenAI CLI terminal
-map({ "n", "t" }, "<A-o>", function()
+-- ALT+w toggles the OpenAI CLI terminal
+map({ "n", "t" }, "<A-w>", function()
   local term = require "nvchad.term"
 
   -- Prepare: handle foreground terminal switching if needed
@@ -993,7 +993,7 @@ map({ "n", "t" }, "<A-o>", function()
       pos = "float",
       id = "openai_term",
       float_opts = {
-        row = 0.06, -- ALT+o: OpenAI CLI
+        row = 0.06, -- ALT+w: OpenAI CLI
         col = 0.06,
         width = 0.85,
         height = 0.85,
@@ -1121,8 +1121,8 @@ fi
   end
 end, { desc = "terminal toggle e1s AWS ECS" })
 
--- ALT+u toggles the posting terminal (API client)
-map({ "n", "t" }, "<A-u>", function()
+-- ALT+r toggles the posting terminal (API client)
+map({ "n", "t" }, "<A-r>", function()
   local term = require "nvchad.term"
 
   -- Prepare: handle foreground terminal switching if needed
@@ -1135,7 +1135,7 @@ map({ "n", "t" }, "<A-u>", function()
       id = "posting_term",
       cmd = "posting",
       float_opts = {
-        row = 0.08, -- ALT+u: Posting API client
+        row = 0.08, -- ALT+r: Posting API client
         col = 0.08,
         width = 0.85,
         height = 0.85,
@@ -1146,10 +1146,10 @@ map({ "n", "t" }, "<A-u>", function()
   end
 end, { desc = "terminal toggle posting API client" })
 
--- ALT+p closes and kills any floating terminal (ALT+i/k/j/h/o/d/e/u)
+-- ALT+z closes and kills any floating terminal
 -- Note: When in terminal mode with apps like k9s running, press Ctrl+q first to exit terminal mode,
--- then press ALT+p. Or use this mapping which attempts to kill the process first.
-map({ "n", "t" }, "<A-p>", function()
+-- then press ALT+z. Or use this mapping which attempts to kill the process first.
+map({ "n", "t" }, "<A-z>", function()
   local bufnr = vim.api.nvim_get_current_buf()
   if vim.bo[bufnr].buftype == "terminal" then
     local nvim_pid = vim.fn.getpid()

--- a/nvim/.config/nvim/lua/mappings.lua
+++ b/nvim/.config/nvim/lua/mappings.lua
@@ -1187,11 +1187,7 @@ map({ "n", "t" }, "<A-z>", function()
 end, { desc = "kill any floating terminal" })
 
 -- Avante.nvim AI assistant keybindings
--- Using ALT+a for "Avante" to match the pattern of other tools (ALT+h, ALT+j, ALT+k, etc)
-map({ "n", "v" }, "<A-a>", function()
-  require("avante.api").ask()
-end, { desc = "avante: ask" })
-
+-- Note: ALT+a is used by Claude terminal, use <leader>aa for avante
 map({ "n", "v" }, "<leader>aa", function()
   require("avante.api").ask()
 end, { desc = "avante: ask" })

--- a/nvim/.config/nvim/lua/mappings.lua
+++ b/nvim/.config/nvim/lua/mappings.lua
@@ -1186,6 +1186,84 @@ map({ "n", "t" }, "<A-z>", function()
   end
 end, { desc = "kill any floating terminal" })
 
+-- ALT+Shift+? shows floating terminal shortcuts cheatsheet
+map({ "n", "t" }, "<A-?>", function()
+  -- Create buffer with shortcut information
+  local buf = vim.api.nvim_create_buf(false, true)
+
+  local shortcuts = {
+    "╭─────────────────────────────────────────────────────╮",
+    "│     Floating Terminal Shortcuts (Left-Hand)        │",
+    "╰─────────────────────────────────────────────────────╯",
+    "",
+    "  Home Row (Most Used)",
+    "  ────────────────────",
+    "  ALT+a  →  Claude Code AI assistant",
+    "  ALT+s  →  Tmux multiplexer terminal",
+    "  ALT+d  →  Lazydocker (Docker TUI)",
+    "  ALT+f  →  Lazygit (Git TUI)",
+    "  ALT+g  →  k9s (Kubernetes browser)",
+    "",
+    "  Top Row (Secondary Tools)",
+    "  ─────────────────────────",
+    "  ALT+w  →  OpenAI Codex CLI",
+    "  ALT+e  →  e1s (AWS ECS browser)",
+    "  ALT+r  →  Posting (HTTP API client)",
+    "",
+    "  Bottom Row",
+    "  ──────────",
+    "  ALT+z  →  Kill/close current terminal",
+    "",
+    "  Command Search",
+    "  ──────────────",
+    "  ALT+q        →  Search all commands",
+    "  ALT+Shift+G  →  Git commands",
+    "  ALT+Shift+D  →  Docker/K8s commands",
+    "  ALT+Shift+A  →  AWS commands",
+    "  ALT+Shift+X  →  Aliases/functions",
+    "  ALT+Shift+B  →  Homebrew packages",
+    "",
+    "  Press any key to close",
+  }
+
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, shortcuts)
+  vim.bo[buf].modifiable = false
+  vim.bo[buf].bufhidden = "wipe"
+
+  -- Calculate centered position
+  local width = 57
+  local height = #shortcuts
+  local row = math.floor((vim.o.lines - height) / 2)
+  local col = math.floor((vim.o.columns - width) / 2)
+
+  -- Open floating window
+  local win = vim.api.nvim_open_win(buf, true, {
+    relative = "editor",
+    width = width,
+    height = height,
+    row = row,
+    col = col,
+    style = "minimal",
+    border = "rounded",
+    title = " Terminal Shortcuts ",
+    title_pos = "center",
+  })
+
+  -- Set window options
+  vim.wo[win].winblend = 10
+  vim.wo[win].cursorline = false
+
+  -- Close on any key press
+  vim.keymap.set("n", "<Esc>", "<cmd>close<CR>", { buffer = buf, nowait = true })
+  vim.keymap.set("n", "q", "<cmd>close<CR>", { buffer = buf, nowait = true })
+  vim.keymap.set("n", "<CR>", "<cmd>close<CR>", { buffer = buf, nowait = true })
+
+  -- Auto-close after any character key
+  for _, key in ipairs({"a", "s", "d", "f", "g", "w", "e", "r", "z", "h", "j", "k", "l"}) do
+    vim.keymap.set("n", key, "<cmd>close<CR>", { buffer = buf, nowait = true })
+  end
+end, { desc = "show terminal shortcuts cheatsheet" })
+
 -- Avante.nvim AI assistant keybindings
 -- Note: ALT+a is used by Claude terminal, use <leader>aa for avante
 map({ "n", "v" }, "<leader>aa", function()

--- a/nvim/.config/nvim/lua/mappings.lua
+++ b/nvim/.config/nvim/lua/mappings.lua
@@ -1250,7 +1250,7 @@ map({ "n", "t" }, "<A-?>", function()
   })
 
   -- Set window options
-  vim.wo[win].winblend = 10
+  vim.wo[win].winblend = 30
   vim.wo[win].cursorline = false
 
   -- Close on any key press


### PR DESCRIPTION
## Summary

Remaps all floating terminal keybindings to left-hand keys for seamless use with tiling window managers (aerospace) that occupy ALT+hjkl; for window management.

## Problem

The current terminal keybindings use both hands:
- Right hand: ALT+k (Claude), ALT+j (k9s), ALT+h (Lazygit), ALT+i (Tmux), ALT+o (OpenAI), ALT+u (Posting), ALT+p (kill)
- Conflicts with aerospace tiling WM using ALT+hjkl; for window navigation

## Solution

Reorganize all terminal shortcuts to the left hand, optimized by usage frequency:

### New Layout

**Home Row (Most Used):**
| Key | Terminal | Previous | Mnemonic |
|-----|----------|----------|----------|
| ALT+a | Claude | ALT+k | **A**I / **A**ssistant |
| ALT+s | Tmux | ALT+i | **S**hell / **S**ession |
| ALT+d | Lazydocker | ALT+d | **D**ocker (unchanged) |
| ALT+f | Lazygit | ALT+h | Git **F**low |
| ALT+g | k9s | ALT+j | Kubernetes (**g** close to "k") |

**Top Row (Secondary Tools):**
| Key | Terminal | Previous | Mnemonic |
|-----|----------|----------|----------|
| ALT+w | OpenAI | ALT+o | Available key |
| ALT+e | e1s | ALT+e | **E**CS (unchanged) |
| ALT+r | Posting | ALT+u | **R**EST API |

**Bottom Row:**
| Key | Terminal | Previous | Mnemonic |
|-----|----------|----------|----------|
| ALT+z | Kill | ALT+p | **Z**ap terminal |

**Unchanged (Already Left-Hand):**
- ALT+q: Fuzzy search all commands
- ALT+Shift+G: Git commands
- ALT+Shift+D: Docker/K8s commands
- ALT+Shift+A: AWS commands
- ALT+Shift+X: Aliases/functions
- ALT+Shift+B: Homebrew packages

## Benefits

✅ **Ergonomic**: All shortcuts on left hand  
✅ **Optimized**: Most-used terminals on home row  
✅ **Compatible**: No conflicts with tiling WM (aerospace)  
✅ **Intuitive**: Mnemonics for each key (Claude=**a**i, Tmux=**s**ession, Lazygit=**f**low, etc.)  
✅ **Maintains**: Command search shortcuts (ALT+q) unchanged  

## Keyboard Layout

```
┌─────┬─────┬─────┬─────┬─────┐
│  q  │  w  │  e  │  r  │  t  │  Top Row
├─────┼─────┼─────┼─────┼─────┤
│  a  │  s  │  d  │  f  │  g  │  Home Row (Most Used)
├─────┼─────┼─────┼─────┼─────┤
│  z  │  x  │  c  │  v  │  b  │  Bottom Row
└─────┴─────┴─────┴─────┴─────┘

a = Claude      (Home Row - Primary)
s = Tmux        (Home Row - Primary)
d = Lazydocker  (Home Row - Primary)
f = Lazygit     (Home Row - Primary)
g = k9s         (Home Row - Primary)

w = OpenAI      (Top Row - Secondary)
e = e1s         (Top Row - Secondary)
r = Posting     (Top Row - Secondary)

z = Kill        (Bottom Row)
```

## Changes

### `nvim/.config/nvim/lua/mappings.lua`
- Updated 7 terminal keybindings
- Changed all float_opts comments to reflect new keys
- ALT+k → ALT+a (Claude)
- ALT+i → ALT+s (Tmux)
- ALT+j → ALT+g (k9s)
- ALT+h → ALT+f (Lazygit)
- ALT+o → ALT+w (OpenAI)
- ALT+u → ALT+r (Posting)
- ALT+p → ALT+z (Kill)

### `CLAUDE.md`
- Updated repository overview (8 tools, left-hand optimized)
- Fixed terminal count (10→8, removed browser CLIs previously)
- Updated Lazygit reference: ALT+h → ALT+f
- Updated k9s reference: ALT+j → ALT+g
- Added comprehensive "Floating Terminal Keybindings" section:
  - Organized by keyboard row (home/top/bottom)
  - Includes mnemonics for each key
  - Documents unchanged command search keys

## Testing Checklist

- [ ] ALT+a opens Claude with session prompt
- [ ] ALT+s opens Tmux with auto-start
- [ ] ALT+d opens Lazydocker
- [ ] ALT+f opens Lazygit
- [ ] ALT+g opens k9s with cluster selection
- [ ] ALT+w opens OpenAI CLI
- [ ] ALT+e opens e1s with profile/region selection
- [ ] ALT+r opens Posting
- [ ] ALT+z kills current terminal and resets flags
- [ ] All auto-start commands execute correctly
- [ ] Old keybindings (k/i/j/h/o/u/p) no longer work
- [ ] Command search (ALT+q, ALT+Shift+G/D/A/X/B) still works

## Migration Notes

Users will need to update muscle memory:
- Claude: k→a
- Tmux: i→s
- k9s: j→g
- Lazygit: h→f
- OpenAI: o→w
- Posting: u→r
- Kill: p→z

Home row placement should make the transition easier for frequently-used terminals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)