### PR TITLE
feat: add AeroSpace tiling window manager configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The result: A development environment where CLI tools aren't separate apps—the
 ## Features
 
 - **Neovim**: CLI-first IDE built on NvChad v2.5 with 8 integrated floating terminals
+- **AeroSpace**: Tiling window manager for macOS with i3-inspired keybindings
 - **Wezterm**: Smart terminal with custom tab formatting, smart-splits integration, and per-directory tab colors
 - **ZSH**: Vi-mode, autosuggestions, syntax highlighting, FZF integration, and secure secrets management
 - **Git**: Version control with comprehensive aliases and modern defaults
@@ -61,6 +62,7 @@ The result: A development environment where CLI tools aren't separate apps—the
  - eza
  - zoxide
  - stow
+ - aerospace (tiling window manager)
  - wezterm
  - starship
  - neovim
@@ -87,7 +89,7 @@ The result: A development environment where CLI tools aren't separate apps—the
 
 ```bash
 brew install eza zoxide stow zsh zsh-vi-mode zsh-autosuggestions zsh-syntax-highlighting starship neovim ripgrep tmux k9s lazydocker git-delta fzf fd bat codex posting awscli e1s
-brew install --cask font-hack-nerd-font wezterm
+brew install --cask font-hack-nerd-font wezterm nikitabobko/tap/aerospace
 ```
 
 ### 2. Clone repository
@@ -105,6 +107,7 @@ rm -f ~/.zshrc
 
 # Stow configurations (creates symlinks from repo to home directory)
 stow git      # Deploys to ~/.gitconfig
+stow aerospace
 stow wezterm
 stow zsh
 stow starship

--- a/aerospace/.aerospace.toml
+++ b/aerospace/.aerospace.toml
@@ -1,0 +1,156 @@
+# Place a copy of this config to ~/.aerospace.toml
+# After that, you can edit ~/.aerospace.toml to your liking
+
+# You can use it to add commands that run after AeroSpace startup.
+# Available commands : https://nikitabobko.github.io/AeroSpace/commands
+after-startup-command = []
+
+# Start AeroSpace at login
+start-at-login = true
+
+# Normalizations. See: https://nikitabobko.github.io/AeroSpace/guide#normalization
+enable-normalization-flatten-containers = true
+enable-normalization-opposite-orientation-for-nested-containers = true
+
+# See: https://nikitabobko.github.io/AeroSpace/guide#layouts
+# The 'accordion-padding' specifies the size of accordion padding
+# You can set 0 to disable the padding feature
+accordion-padding = 0
+
+# Possible values: tiles|accordion
+default-root-container-layout = 'tiles'
+
+# Possible values: horizontal|vertical|auto
+# 'auto' means: wide monitor (anything wider than high) gets horizontal orientation,
+#               tall monitor (anything higher than wide) gets vertical orientation
+default-root-container-orientation = 'auto'
+
+# Mouse follows focus when focused monitor changes
+# Drop it from your config, if you don't like this behavior
+# See https://nikitabobko.github.io/AeroSpace/guide#on-focus-changed-callbacks
+# See https://nikitabobko.github.io/AeroSpace/commands#move-mouse
+# Fallback value (if you omit the key): on-focused-monitor-changed = []
+on-focus-changed = ['move-mouse window-lazy-center'] # Mouse lazily follows any focus (window or workspace)
+on-focused-monitor-changed = ['move-mouse monitor-lazy-center']
+
+# You can effectively turn off macOS "Hide application" (cmd-h) feature by toggling this flag
+# Useful if you don't use this macOS feature, but accidentally hit cmd-h or cmd-alt-h key
+# Also see: https://nikitabobko.github.io/AeroSpace/goodies#disable-hide-app
+automatically-unhide-macos-hidden-apps = false
+
+# Possible values: (qwerty|dvorak|colemak)
+# See https://nikitabobko.github.io/AeroSpace/guide#key-mapping
+[key-mapping]
+    preset = 'qwerty'
+
+# Gaps between windows (inner-*) and between monitor edges (outer-*).
+# Possible values:
+# - Constant:     gaps.outer.top = 8
+# - Per monitor:  gaps.outer.top = [{ monitor.main = 16 }, { monitor."some-pattern" = 32 }, 24]
+#                 In this example, 24 is a default value when there is no match.
+#                 Monitor pattern is the same as for 'workspace-to-monitor-force-assignment'.
+#                 See:
+#                 https://nikitabobko.github.io/AeroSpace/guide#assign-workspaces-to-monitors
+[gaps]
+    inner.horizontal = 0
+    inner.vertical =   0
+    outer.left =       0
+    outer.bottom =     0
+    outer.top =        0
+    outer.right =      0
+
+# 'main' binding mode declaration
+# See: https://nikitabobko.github.io/AeroSpace/guide#binding-modes
+# 'main' binding mode must be always presented
+# Fallback value (if you omit the key): mode.main.binding = {}
+[mode.main.binding]
+
+    # All possible keys:
+    # - Letters.        a, b, c, ..., z
+    # - Numbers.        0, 1, 2, ..., 9
+    # - Keypad numbers. keypad0, keypad1, keypad2, ..., keypad9
+    # - F-keys.         f1, f2, ..., f20
+    # - Special keys.   minus, equal, period, comma, slash, backslash, quote, semicolon,
+    #                   backtick, leftSquareBracket, rightSquareBracket, space, enter, esc,
+    #                   backspace, tab, pageUp, pageDown, home, end, forwardDelete,
+    #                   sectionSign (ISO keyboards only, european keyboards only)
+    # - Keypad special. keypadClear, keypadDecimalMark, keypadDivide, keypadEnter, keypadEqual,
+    #                   keypadMinus, keypadMultiply, keypadPlus
+    # - Arrows.         left, down, up, right
+
+    # All possible modifiers: cmd, alt, ctrl, shift
+
+    # All possible commands: https://nikitabobko.github.io/AeroSpace/commands
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#exec-and-forget
+    # You can uncomment the following lines to open up terminal with alt + enter shortcut
+    # (like in i3)
+    # alt-enter = '''exec-and-forget osascript -e '
+    # tell application "Terminal"
+    #     do script
+    #     activate
+    # end tell'
+    # '''
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#layout
+    alt-rightSquareBracket = 'layout tiles horizontal vertical'
+    alt-leftSquareBracket = 'layout accordion horizontal vertical'
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#focus
+    alt-h = 'focus --boundaries-action wrap-around-the-workspace left'
+    alt-j = 'focus --boundaries-action wrap-around-the-workspace down'
+    alt-k = 'focus --boundaries-action wrap-around-the-workspace up'
+    alt-l = 'focus --boundaries-action wrap-around-the-workspace right'
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#move
+    alt-shift-h = 'move left'
+    alt-shift-j = 'move down'
+    alt-shift-k = 'move up'
+    alt-shift-l = 'move right'
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#resize
+    alt-minus = 'resize smart -50'
+    alt-equal = 'resize smart +50'
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#workspace
+    alt-1 = 'workspace 1'
+    alt-2 = 'workspace 2'
+    alt-3 = 'workspace 3'
+    alt-4 = 'workspace 4'
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#move-node-to-workspace
+    alt-shift-1 = 'move-node-to-workspace 1'
+    alt-shift-2 = 'move-node-to-workspace 2'
+    alt-shift-3 = 'move-node-to-workspace 3'
+    alt-shift-4 = 'move-node-to-workspace 4'
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#workspace-back-and-forth
+    alt-tab = 'workspace-back-and-forth'
+    # See: https://nikitabobko.github.io/AeroSpace/commands#move-workspace-to-monitor
+    alt-shift-tab = 'move-workspace-to-monitor --wrap-around next'
+
+    # See: https://nikitabobko.github.io/AeroSpace/commands#mode
+    alt-shift-semicolon = 'mode service'
+
+    alt-shift-rightSquareBracket = 'workspace next --wrap-around'
+    alt-shift-leftSquareBracket = 'workspace prev --wrap-around'
+
+# 'service' binding mode declaration.
+# See: https://nikitabobko.github.io/AeroSpace/guide#binding-modes
+[mode.service.binding]
+    esc = ['reload-config', 'mode main']
+    r = ['flatten-workspace-tree', 'mode main'] # reset layout
+    f = ['layout floating tiling', 'mode main'] # Toggle between floating and tiling layout
+    backspace = ['close-all-windows-but-current', 'mode main']
+
+    # sticky is not yet supported https://github.com/nikitabobko/AeroSpace/issues/2
+    #s = ['layout sticky tiling', 'mode main']
+
+    alt-shift-h = ['join-with left', 'mode main']
+    alt-shift-j = ['join-with down', 'mode main']
+    alt-shift-k = ['join-with up', 'mode main']
+    alt-shift-l = ['join-with right', 'mode main']
+
+    down = 'volume down'
+    up = 'volume up'
+    shift-down = ['volume set 0', 'mode main']


### PR DESCRIPTION
## Summary

Adds **AeroSpace** tiling window manager configuration to Paradiddle's stow-managed dotfiles, providing i3-inspired window management for macOS.

## Motivation

AeroSpace complements the CLI-first philosophy by bringing tiling window management to macOS. With vim-style navigation keybindings and workspace management, it creates a seamless keyboard-driven environment that pairs perfectly with Neovim's floating terminal workflow.

## Changes

### New Configuration
- ✅ **aerospace/.aerospace.toml** - Full AeroSpace configuration with:
  - i3-inspired keybindings (ALT+hjkl for focus, ALT+Shift+hjkl for move)
  - 4 workspaces with ALT+1/2/3/4 switching
  - Zero-gap tiling (edge-to-edge windows)
  - Auto-orientation based on monitor aspect ratio
  - Mouse follows focus behavior
  - Service mode for advanced operations (ALT+Shift+;)

### Documentation Updates
- ✅ **README.md** updated with:
  - AeroSpace in Features section
  - aerospace added to Requirements list
  - Installation instructions (homebrew cask)
  - Stow deployment step

## AeroSpace Keybindings

### Window Focus & Movement
| Shortcut | Action |
|----------|--------|
| `ALT+h/j/k/l` | Focus window (left/down/up/right) |
| `ALT+Shift+h/j/k/l` | Move window (left/down/up/right) |
| `ALT+minus` | Resize smart -50px |
| `ALT+equal` | Resize smart +50px |

### Workspace Management
| Shortcut | Action |
|----------|--------|
| `ALT+1/2/3/4` | Switch to workspace 1/2/3/4 |
| `ALT+Shift+1/2/3/4` | Move window to workspace 1/2/3/4 |
| `ALT+Tab` | Switch to previous workspace |
| `ALT+Shift+Tab` | Move workspace to next monitor |
| `ALT+Shift+[/]` | Navigate workspaces (prev/next) |

### Layout Management
| Shortcut | Action |
|----------|--------|
| `ALT+]` | Toggle tiles layout (horizontal/vertical) |
| `ALT+[` | Toggle accordion layout |
| `ALT+Shift+;` | Enter service mode |

### Service Mode (ALT+Shift+;)
| Shortcut | Action |
|----------|--------|
| `esc` | Reload config & exit service mode |
| `r` | Reset layout (flatten workspace tree) |
| `f` | Toggle floating/tiling |
| `backspace` | Close all windows except current |
| `ALT+Shift+h/j/k/l` | Join windows in direction |
| `up/down` | Volume control |

## Configuration Highlights

- **Zero gaps**: `inner/outer` gaps all set to 0 for maximum screen space
- **Auto-orientation**: Wide monitors get horizontal splits, tall monitors get vertical
- **Mouse follows focus**: Cursor automatically moves to focused window center
- **Start at login**: Launches automatically on macOS startup
- **Normalization enabled**: Flattens containers and handles nested containers intelligently
- **QWERTY preset**: Standard keyboard layout (configurable for Dvorak/Colemak)

## Installation

```bash
# Install AeroSpace via homebrew
brew install --cask nikitabobko/tap/aerospace

# Remove existing config if present
rm -f ~/.aerospace.toml

# Deploy with stow
stow aerospace

# Start AeroSpace
open -a AeroSpace
```

## Integration with Paradiddle

AeroSpace enhances the existing CLI-first workflow:

1. **Tiling Layout**: Automatic window arrangement (no manual dragging)
2. **Keyboard Navigation**: ALT+hjkl matches Neovim's floating terminal navigation philosophy
3. **Workspace Management**: Organize terminals, browsers, and Neovim instances across 4 workspaces
4. **Zero Distractions**: Edge-to-edge tiling maximizes screen space
5. **Seamless with Wezterm**: Ctrl+hjkl navigates within wezterm/nvim panes, ALT+hjkl navigates between windows

## Example Workflow

**Multi-Project Development:**
1. **Workspace 1**: Wezterm + Neovim (main project)
2. **Workspace 2**: Browser (documentation)
3. **Workspace 3**: Wezterm + Neovim (microservice)
4. **Workspace 4**: Slack/communication

Navigate instantly with ALT+1/2/3/4, focus windows with ALT+hjkl, move windows with ALT+Shift+hjkl.

## File Changes

- **aerospace/.aerospace.toml** (new file, 157 lines)
- **README.md** (+4 changes: Features, Requirements, Installation, Stow steps)

## Testing

- [x] Configuration file created at `aerospace/.aerospace.toml`
- [x] README updated with aerospace in all relevant sections
- [x] Stow deployment works (`stow aerospace` creates `~/.aerospace.toml` symlink)
- [x] AeroSpace launches and reads configuration correctly
- [x] All keybindings tested and working

## References

- AeroSpace GitHub: https://github.com/nikitabobko/AeroSpace
- AeroSpace Documentation: https://nikitabobko.github.io/AeroSpace/guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)