### PR TITLE
fix: add missing Alfred custom web search and bookmarks preferences

### DIFF
--- a/alfred/Alfred.alfredpreferences/preferences/features/webbookmarks/prefs.plist
+++ b/alfred/Alfred.alfredpreferences/preferences/features/webbookmarks/prefs.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>keyword</key>
+	<string>b</string>
+	<key>mode</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/alfred/Alfred.alfredpreferences/preferences/features/websearch/prefs.plist
+++ b/alfred/Alfred.alfredpreferences/preferences/features/websearch/prefs.plist
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>customSites</key>
+	<dict>
+		<key>01C74E40-40B4-4987-9C24-C60825C43DDC</key>
+		<dict>
+			<key>enabled</key>
+			<true/>
+			<key>keyword</key>
+			<string>w</string>
+			<key>text</key>
+			<string>Weather</string>
+			<key>url</key>
+			<string>https://www.google.com/search?q=weather+{query}</string>
+		</dict>
+		<key>2AF2FB1A-90CE-4FCE-AE98-1DCACD8A5F2E</key>
+		<dict>
+			<key>enabled</key>
+			<true/>
+			<key>keyword</key>
+			<string>d</string>
+			<key>text</key>
+			<string>Search docs</string>
+			<key>url</key>
+			<string>https://docs.google.com/document/u/0/?tgif=d&amp;q={query}</string>
+		</dict>
+		<key>61F61CAD-FB37-4758-AEC2-A527438A6A70</key>
+		<dict>
+			<key>enabled</key>
+			<true/>
+			<key>keyword</key>
+			<string>cal</string>
+			<key>text</key>
+			<string>Open calendar</string>
+			<key>url</key>
+			<string>https://calendar.google.com/</string>
+		</dict>
+		<key>7D4BBE8C-2A11-4C63-9E3C-230B292DF59D</key>
+		<dict>
+			<key>enabled</key>
+			<true/>
+			<key>keyword</key>
+			<string>t</string>
+			<key>text</key>
+			<string>Open twitch</string>
+			<key>url</key>
+			<string>https://www.twitch.tv/{query}</string>
+		</dict>
+	</dict>
+	<key>onlyShowEnabledInPrefs</key>
+	<true/>
+</dict>
+</plist>

--- a/alfred/README.md
+++ b/alfred/README.md
@@ -7,7 +7,7 @@ This directory contains **only custom Alfred configurations** - default settings
 ```
 alfred/
 └── Alfred.alfredpreferences/
-    ├── preferences/    # Custom feature preferences (7 files)
+    ├── preferences/    # Custom feature preferences (9 files)
     │   ├── appearance/options/prefs.plist
     │   └── features/
     │       ├── calculator/prefs.plist
@@ -15,15 +15,17 @@ alfred/
     │       ├── contacts/prefs.plist
     │       ├── itunes/prefs.plist
     │       ├── system/prefs.plist
-    │       └── terminal/prefs.plist
+    │       ├── terminal/prefs.plist
+    │       ├── webbookmarks/prefs.plist
+    │       └── websearch/prefs.plist
     └── resources/      # Custom web search icons (4 files)
 ```
 
 ## What's Included
 
-**Only custom/personalized configurations** - 12 files, 72KB total.
+**Only custom/personalized configurations** - 14 files, 74KB total.
 
-### Custom Preferences (7 files)
+### Custom Preferences (9 files)
 - **calculator**: Disabled
 - **contacts**: Disabled
 - **clipboard**: Custom hotkey (Cmd+Opt+C), 2-item limit, 3-month persistence
@@ -31,6 +33,12 @@ alfred/
 - **terminal**: WezTerm integration with CLI support
 - **system**: Custom keywords (`et` for empty trash, `lock` for screensaver), volume controls disabled
 - **appearance**: Auto-highlight disabled, hat/menu hidden, custom screen positioning
+- **websearch**: 4 custom web searches
+  - `w` - Weather (Google weather search)
+  - `d` - Search docs (Google Docs)
+  - `cal` - Open calendar (Google Calendar)
+  - `t` - Open twitch (Twitch.tv)
+- **webbookmarks**: Custom keyword `b`, mode 1
 
 ### Custom Resources (4 files)
 - **4 custom web search icons** (Twitch, Calendar, Docs, Weather)
@@ -181,8 +189,8 @@ If still not working, check `alfred/Alfred.alfredpreferences/preferences/feature
 
 ## Notes
 
-- **Total size:** 72KB (12 files)
-- **Only truly custom content:** 7 preference files with your custom settings + 4 web search icons
+- **Total size:** 74KB (14 files)
+- **Only truly custom content:** 9 preference files with your custom settings + 4 web search icons + 1 README
 - **Alfred will apply defaults** for any preferences not included (web searches, file search, dictionary, etc.)
 - **WezTerm integration:** Terminal script uses `wezterm cli send-text` for proper command execution
 - **No symlinks needed:** Alfred's native sync feature handles everything


### PR DESCRIPTION
## Problem

After merging PR #39, Alfred custom web search and bookmarks settings were missing from the repo. We had included the 4 custom web search **icons** (PNG files) but not the **preference files** that define what those searches actually do.

## What Was Missing

- **Custom web search definitions** - The `websearch/prefs.plist` file containing 4 custom searches
- **Web bookmarks settings** - The `webbookmarks/prefs.plist` file with custom keyword

## Added Files

### websearch/prefs.plist
Defines 4 custom web searches:
- ✅ `w` → Weather (Google weather search)
- ✅ `d` → Search docs (Google Docs search)
- ✅ `cal` → Open calendar (Google Calendar)
- ✅ `t` → Open twitch (Twitch.tv/{query})

### webbookmarks/prefs.plist
Custom web bookmarks settings:
- ✅ Keyword: `b`
- ✅ Mode: 1

## Updated Documentation

- Structure diagram now shows **9 preference files** (was 7)
- "What's Included" section details the 4 custom searches
- **Total: 14 files, 74KB** (was 12 files, 72KB)

## Why This Was Missed

During PR #39 cleanup, we correctly kept the custom web search **icons** (4 PNG files with UUID names) but accidentally missed the **definitions file**. Custom searches in Alfred are stored in a single `websearch/prefs.plist` file under the `customSites` dictionary, not in separate directories like default searches.

## Testing

On new laptop after setting Alfred sync folder:
- [x] Custom searches now appear in Alfred
- [x] `w` search works (weather)
- [x] `d` search works (docs)
- [x] `cal` opens calendar
- [x] `t` opens twitch
- [x] Web bookmarks keyword `b` works

## Impact

**Before this fix:** Setting Alfred's sync folder would include custom icons but searches wouldn't work (no definitions).

**After this fix:** All custom web searches and bookmarks work as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)