### PR TITLE
fix: Alfred WezTerm integration cutting off first character

### DIFF
--- a/alfred/Alfred.alfredpreferences/preferences/features/terminal/prefs.plist
+++ b/alfred/Alfred.alfredpreferences/preferences/features/terminal/prefs.plist
@@ -9,7 +9,7 @@
 	tell application "WezTerm"
 		activate
 	end tell
-	do shell script "/Applications/WezTerm.app/Contents/MacOS/wezterm cli send-text --no-paste " &amp; quoted form of (q &amp; return)
+	do shell script "/Applications/WezTerm.app/Contents/MacOS/wezterm cli send-text --no-paste -- " &amp; quoted form of (q &amp; linefeed)
 end alfred_script</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Problem

When running commands from Alfred using the `>` prefix (e.g., `> vim ~/.zshrc`), the first character is being cut off. Example:
- Input: `> vim ~/.zshrc`
- Executed: `im ~/.zshrc` ❌

## Root Cause

The command was being parsed as part of wezterm's CLI arguments instead of as text to send to the terminal, causing argument parsing to consume the first character.

## Fix

Added `--` separator to explicitly mark the end of wezterm CLI arguments:

**Before:**
```applescript
do shell script "wezterm cli send-text --no-paste " & quoted form of (q & return)
```

**After:**
```applescript
do shell script "wezterm cli send-text --no-paste -- " & quoted form of (q & linefeed)
```

**Changes:**
1. ✅ Added `--` to separate wezterm arguments from text to send
2. ✅ Changed `return` to `linefeed` (proper AppleScript constant)

## Testing

After merging and reloading Alfred preferences:

1. Type in Alfred: `> vim ~/.zshrc`
   - Expected: Executes `vim ~/.zshrc` ✅
   - Previously: Executed `im ~/.zshrc` ❌

2. Type in Alfred: `> ls -la`
   - Expected: Executes `ls -la` ✅
   - Previously: Executed `s -la` ❌

## Files Changed

- `alfred/Alfred.alfredpreferences/preferences/features/terminal/prefs.plist`

Since Alfred uses native sync, the fix will be live immediately after merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)