### PR TITLE
docs: add missing lazygit and claude dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,12 @@ The result: A development environment where CLI tools aren't separate apps—the
  - ripgrep
  - tmux
  - k9s
+ - lazygit (Git TUI)
  - lazydocker (Docker TUI)
  - fzf (fuzzy finder)
  - fd (find alternative)
  - bat (cat alternative with syntax highlighting)
+ - claude (Claude Code CLI - installed via npm)
  - codex (OpenAI Codex CLI)
  - posting (HTTP API client TUI)
  - e1s (AWS ECS terminal UI)
@@ -90,8 +92,11 @@ The result: A development environment where CLI tools aren't separate apps—the
 ### 1. Install Homebrew dependencies
 
 ```bash
-brew install eza zoxide stow zsh zsh-vi-mode zsh-autosuggestions zsh-syntax-highlighting starship neovim ripgrep tmux k9s lazydocker git-delta fzf fd bat codex posting awscli e1s
+brew install eza zoxide stow zsh zsh-vi-mode zsh-autosuggestions zsh-syntax-highlighting starship neovim ripgrep tmux k9s lazygit lazydocker git-delta fzf fd bat codex posting awscli e1s
 brew install --cask font-hack-nerd-font wezterm nikitabobko/tap/aerospace alfred
+
+# Install Claude Code CLI via npm
+npm install -g @anthropic-ai/claude-code
 ```
 
 ### 2. Clone repository


### PR DESCRIPTION
## Problem

The README was missing 2 critical dependencies used by the floating terminals:
- **lazygit** - Git TUI (ALT+f terminal)
- **claude** - Claude Code CLI (ALT+a terminal)

## Changes

### Requirements List
Added to the requirements section:
- ✅ **lazygit (Git TUI)**
- ✅ **claude (Claude Code CLI - installed via npm)**

### Installation Instructions

**brew install command:**
```bash
brew install ... lazygit ...
```

**New npm install step:**
```bash
# Install Claude Code CLI via npm
npm install -g @anthropic-ai/claude-code
```

## Why This Was Missed

PR #40 focused on Alfred preferences and was merged before these dependency additions were pushed. This PR adds the missing tool dependencies.

## Testing

After merging, new users following the README will have:
- [x] lazygit available for ALT+f (Git TUI)
- [x] claude available for ALT+a (AI assistant)
- [x] Complete set of CLI tool dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)