### PR TITLE
feat: curated 7-color palette for SketchyBar app names

### DIFF
--- a/sketchybar/.config/sketchybar/hash_color_fn.sh
+++ b/sketchybar/.config/sketchybar/hash_color_fn.sh
@@ -4,18 +4,18 @@
 function hash_color() {
   local app_name="$1"
 
-  # Define 10 neon pastel colors
+  # Define 10 distinct neon pastel colors (spread across color wheel)
   local colors=(
-    "0xffff6ec7"  # Neon Pink
-    "0xff8bffa3"  # Neon Mint Green
-    "0xffffb86c"  # Neon Peach
-    "0xff7dd3fc"  # Neon Sky Blue
-    "0xffffa6ff"  # Neon Lavender
-    "0xffffeb3b"  # Neon Lemon
-    "0xffff6b6b"  # Neon Coral
-    "0xff6bffcc"  # Neon Aqua
-    "0xffffaa00"  # Neon Orange
-    "0xffbd93f9"  # Neon Purple
+    "0xffff5555"  # Bright Red
+    "0xffff9d00"  # Bright Orange
+    "0xffffd700"  # Bright Gold
+    "0xff50fa7b"  # Bright Green
+    "0xff00f5ff"  # Bright Cyan
+    "0xff5599ff"  # Bright Blue
+    "0xffbb88ff"  # Bright Purple
+    "0xffff55ff"  # Bright Magenta
+    "0xffaaff00"  # Bright Lime
+    "0xffff69b4"  # Bright Pink
   )
 
   # Generate hash from app name (use cksum for portability)

--- a/sketchybar/.config/sketchybar/hash_color_fn.sh
+++ b/sketchybar/.config/sketchybar/hash_color_fn.sh
@@ -4,25 +4,22 @@
 function hash_color() {
   local app_name="$1"
 
-  # Define 10 distinct colors (spread across color wheel)
+  # Define 7 distinct colors (evenly spread across color wheel)
   local colors=(
-    "0xffff8888"  # Coral Red (muted)
+    "0xffff8888"  # Coral Red
     "0xffff9d00"  # Bright Orange
     "0xffffd700"  # Bright Gold
     "0xff50fa7b"  # Bright Green
-    "0xff00d4aa"  # Bright Teal
     "0xff5599ff"  # Bright Blue
-    "0xff6b5cff"  # Bright Indigo
     "0xffbb88ff"  # Bright Purple
     "0xffff69b4"  # Bright Pink
-    "0xffffb380"  # Peach
   )
 
   # Generate hash from app name (use cksum for portability)
   local hash=$(echo -n "$app_name" | cksum | awk '{print $1}')
 
   # Select color deterministically using modulo
-  local color_index=$((hash % 10))
+  local color_index=$((hash % 7))
 
   # Return the selected color
   echo "${colors[$color_index]}"

--- a/sketchybar/.config/sketchybar/hash_color_fn.sh
+++ b/sketchybar/.config/sketchybar/hash_color_fn.sh
@@ -4,16 +4,28 @@
 function hash_color() {
   local app_name="$1"
 
+  # Define 10 neon pastel colors
+  local colors=(
+    "0xffff6ec7"  # Neon Pink
+    "0xff8bffa3"  # Neon Mint Green
+    "0xffffb86c"  # Neon Peach
+    "0xff7dd3fc"  # Neon Sky Blue
+    "0xffffa6ff"  # Neon Lavender
+    "0xffffeb3b"  # Neon Lemon
+    "0xffff6b6b"  # Neon Coral
+    "0xff6bffcc"  # Neon Aqua
+    "0xffffaa00"  # Neon Orange
+    "0xffbd93f9"  # Neon Purple
+  )
+
   # Generate hash from app name (use cksum for portability)
   local hash=$(echo -n "$app_name" | cksum | awk '{print $1}')
 
-  # Extract RGB components from hash (ensure good color distribution)
-  local r=$(( (hash >> 16) % 156 + 100 ))  # 100-255 range
-  local g=$(( (hash >> 8) % 156 + 100 ))   # 100-255 range
-  local b=$(( hash % 156 + 100 ))          # 100-255 range
+  # Select color deterministically using modulo
+  local color_index=$((hash % 10))
 
-  # Format as hex color with full opacity
-  printf "0xff%02x%02x%02x" $r $g $b
+  # Return the selected color
+  echo "${colors[$color_index]}"
 }
 
 hash_color "$1"

--- a/sketchybar/.config/sketchybar/hash_color_fn.sh
+++ b/sketchybar/.config/sketchybar/hash_color_fn.sh
@@ -4,18 +4,18 @@
 function hash_color() {
   local app_name="$1"
 
-  # Define 10 distinct neon pastel colors (spread across color wheel)
+  # Define 10 distinct colors (spread across color wheel)
   local colors=(
-    "0xffff5555"  # Bright Red
+    "0xffff8888"  # Coral Red (muted)
     "0xffff9d00"  # Bright Orange
     "0xffffd700"  # Bright Gold
     "0xff50fa7b"  # Bright Green
-    "0xff00f5ff"  # Bright Cyan
+    "0xff00d4aa"  # Bright Teal
     "0xff5599ff"  # Bright Blue
+    "0xff6b5cff"  # Bright Indigo
     "0xffbb88ff"  # Bright Purple
-    "0xffff55ff"  # Bright Magenta
-    "0xffaaff00"  # Bright Lime
     "0xffff69b4"  # Bright Pink
+    "0xffffb380"  # Peach
   )
 
   # Generate hash from app name (use cksum for portability)

--- a/sketchybar/.config/sketchybar/icon_map_fn.sh
+++ b/sketchybar/.config/sketchybar/icon_map_fn.sh
@@ -37,7 +37,7 @@ function icon_map() {
     icon_result="󰍡"
     ;;
   # Productivity
-  "Alfred" | "Alfred 5")
+  "Alfred" | "Alfred 5" | "Alfred Preferences")
     icon_result="󰘧"
     ;;
   "1Password")


### PR DESCRIPTION
## Summary

This PR replaces the dynamic RGB color generation for SketchyBar app names with a curated palette of 7 distinct colors, providing better visual consistency and recognition.

## Changes

### Curated Color Palette

Replaced random RGB generation (`hash >> 16 % 156 + 100`) with a carefully selected set of 7 colors evenly distributed across the color wheel:

1. 🔴 **Coral Red** - `#ff8888` (muted, not too bright)
2. 🟠 **Bright Orange** - `#ff9d00`
3. 🟡 **Bright Gold** - `#ffd700`
4. 🟢 **Bright Green** - `#50fa7b`
5. 🔵 **Bright Blue** - `#5599ff`
6. 🟣 **Bright Purple** - `#bb88ff`
7. 🩷 **Bright Pink** - `#ff69b4`

### Color Selection Algorithm

- Each app name deterministically maps to one color via `hash % 7`
- Same app = same color (always)
- Colors chosen to be easily distinguishable from each other

### Removed Similar Colors

During refinement, removed colors that were too similar:
- ❌ **Neon Cyan** (too similar to Blue)
- ❌ **Neon Teal** (too similar to Blue/Green)
- ❌ **Neon Indigo** (too similar to Blue/Purple)
- ❌ **Bright Lime** (redundant with Green)
- ❌ **Bright Magenta** (too similar to Purple/Pink)
- ❌ **Peach** (redundant with Orange)

## Benefits

✅ **Visual Consistency** - Apps always appear in the same recognizable color
✅ **Better Contrast** - No similar hues that could be confused
✅ **Clean Aesthetic** - Carefully chosen neon pastel palette
✅ **Deterministic** - Hash-based selection ensures same app = same color
✅ **Maintainable** - Easy to adjust individual colors if needed

## Implementation

**File:** `sketchybar/.config/sketchybar/hash_color_fn.sh`

```bash
# Define 7 distinct colors (evenly spread across color wheel)
local colors=(
  "0xffff8888"  # Coral Red
  "0xffff9d00"  # Bright Orange
  "0xffffd700"  # Bright Gold
  "0xff50fa7b"  # Bright Green
  "0xff5599ff"  # Bright Blue
  "0xffbb88ff"  # Bright Purple
  "0xffff69b4"  # Bright Pink
)

# Select color deterministically using modulo
local color_index=$((hash % 7))
```

## Additional Fix

### Icon Mapping Update
- Added "Alfred Preferences" to Alfred icon mapping
- Ensures Alfred preferences window shows the correct Alfred icon

## Testing

- ✅ All app names display in deterministic colors
- ✅ Colors remain consistent across SketchyBar restarts
- ✅ No two colors are visually similar
- ✅ Active workspace icons match focused app color
- ✅ Front app name shows correct hash-based color

## Related

- Builds on top of merged PR #45 (SketchyBar configuration)
- Separate from PR #46 (multi-instance terminals)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>