### PR TITLE
fix: strip invisible Unicode characters from aerospace app names

### DIFF
--- a/sketchybar/.config/sketchybar/scripts/aerospace.sh
+++ b/sketchybar/.config/sketchybar/scripts/aerospace.sh
@@ -4,8 +4,15 @@ source "$CONFIG_DIR/colors.sh"
 source "$CONFIG_DIR/icon_map_fn.sh"
 source "$CONFIG_DIR/hash_color_fn.sh"
 
+# Strip invisible Unicode characters (like LEFT-TO-RIGHT MARK U+200E)
+strip_invisible() {
+  # Remove common invisible Unicode: LTR mark, RTL mark, zero-width space, etc.
+  echo "$1" | sed 's/[​‎‏]//g'
+}
+
 # Get the focused app name
 FOCUSED_APP=$(aerospace list-windows --focused | awk -F'|' '{gsub(/^ *| *$/, "", $2); print $2}')
+FOCUSED_APP=$(strip_invisible "$FOCUSED_APP")
 APP_COLOR=$(hash_color "$FOCUSED_APP")
 
 if [ "$1" = "$FOCUSED_WORKSPACE" ]; then
@@ -32,7 +39,9 @@ for sid in $(aerospace list-workspaces --all); do
   icon_strip=" "
   if [ "${apps}" != "" ]; then
     while read -r app; do
-      icon=$(icon_map "$app")
+      # Strip invisible Unicode characters before icon lookup
+      clean_app=$(strip_invisible "$app")
+      icon=$(icon_map "$clean_app")
       icon_strip+="$icon "
     done <<<"${apps}"
   else


### PR DESCRIPTION
## Summary

Fixes WhatsApp and other apps with invisible Unicode formatting characters not showing correct icons in SketchyBar's aerospace module.

## Problem

Some applications include invisible Unicode formatting characters in their names when queried via `aerospace list-windows`:

- **WhatsApp**: Returns `‎WhatsApp` with U+200E (LEFT-TO-RIGHT MARK)
- Raw bytes: `342 200 216 W h a t s A p p`
- Expected: `WhatsApp` (no invisible characters)

This caused icon lookups to fail because `icon_map_fn.sh` patterns don't include these invisible characters.

## Solution

Added `strip_invisible()` function in `aerospace.sh` that removes common invisible Unicode characters before icon lookup:
- U+200E (LEFT-TO-RIGHT MARK)
- U+200F (RIGHT-TO-LEFT MARK)
- U+200B (ZERO WIDTH SPACE)

Applied to:
1. **Focused app name** (`FOCUSED_APP`) for color hash calculation
2. **Icon strip generation** (all workspace windows) for icon display

## Testing

### Before Fix
```bash
aerospace list-windows --all | grep -i whats | awk -F'|' '{print $2}' | od -c
# 0000000  342 200 216   W   h   a   t   s   A   p   p
icon_map "‎WhatsApp"  # Returns: 🔲 (fallback icon)
```

### After Fix
```bash
strip_invisible "‎WhatsApp" | od -c
# 0000000    W   h   a   t   s   A   p   p
icon_map "WhatsApp"  # Returns: 󰖣 (correct WhatsApp icon)
```

## Impact

✅ WhatsApp now shows correct icon (󰖣) in SketchyBar  
✅ Any other apps with invisible Unicode formatting will now work  
✅ Backward compatible - apps without invisible characters unaffected

## Files Changed

- `sketchybar/.config/sketchybar/scripts/aerospace.sh`: Added `strip_invisible()` function and applied to app name processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)